### PR TITLE
Update test resources blogs

### DIFF
--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -22,9 +22,6 @@ Lista blogów prowadzonych przez polaków, lub zawierających przynajmniej czę�
   * Maciej Kusz
 * [https://marcinstanek.pl/blog/](https://marcinstanek.pl/blog/)
   * Marcin Stanek
-
-* [https://gregkaqa.pl/](https://gregkaqa.pl/)
-  * Grzegorz Kasprzak
 * [http://malgosqa.pl/](http://malgosqa.pl/)
   * Małgorzata Leszczuk
 * [https://www.leanqa.pl/blog/](https://www.leanqa.pl/blog/)

--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -18,8 +18,6 @@ Lista blogów prowadzonych przez polaków, lub zawierających przynajmniej czę�
   * Maciej Wyrodek
 * [https://testelka.pl/blog/](https://testelka.pl/blog/)
   * Ela Sądel
-* [https://jakosctobedzie.pl/](https://jakosctobedzie.pl/)
-  * Magda Drechsler-Nowak
 * [https://devowls.io/blog/](https://devowls.io/blog/)
   * Michał Krzyżanowski, Michał Ślęzak
 * [https://testerembyc.pl/](https://testerembyc.pl/)

--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -4,24 +4,18 @@ Lista blogów prowadzonych przez polaków, lub zawierających przynajmniej czę�
 
 ## Lista blogów
 
-* [https://testujemy.mobi](https://testujemy.mobi)
-  * Piotr Wicherski
 * [http://testerzy.pl/](http://testerzy.pl/)
   * Testerzy.pl
-* [http://blog.testuj.pl/](http://blog.testuj.pl/)
-  * Testuj.pl Blog
-* [http://awesome-testing.com/](http://awesome-testing.com/)
+* [http://awesome-testing.com/blog](http://awesome-testing.com/blog)
   * Sławomir Radzymiński
 * [http://jakzostactesterem.pl/](http://jakzostactesterem.pl/)
   * Blog pewnego Michała
-* [https://wyrodek.pl](https://wyrodek.pl/)
+* [https://wyrodek.pl/blog](https://wyrodek.pl/blog/)
   * Maciej Wyrodek
 * [https://testelka.pl/blog/](https://testelka.pl/blog/)
   * Ela Sądel
 * [https://testerembyc.pl/](https://testerembyc.pl/)
   * Maciej Kusz
-* [https://marcinstanek.pl/blog/](https://marcinstanek.pl/blog/)
-  * Marcin Stanek
 * [https://wyszkolewas.com.pl/blog/](https://www.wyszkolewas.com.pl/blog/)
   * Waldemar Szafraniec
 * [https://jaktestowac.pl/blog/](https://jaktestowac.pl/blog/)
@@ -32,7 +26,7 @@ Lista blogów prowadzonych przez polaków, lub zawierających przynajmniej czę�
   * Dominik Stolarski, Paweł Kandybowicz, Maciek Florys
 * [https://www.dlatesterow.pl/](https://www.dlatesterow.pl/)
   * Rafał Krząpa
-* [http://www.cyfrowytrener.pl/](http://www.cyfrowytrener.pl/)
+* [http://www.cyfrowytrener.pl/blog](http://www.cyfrowytrener.pl/blog)
   * Kris Pacholski
 * [https://testowanie-oprogramowania.pl/blog/](https://testowanie-oprogramowania.pl/blog/)
   * Rafał Podraza
@@ -40,15 +34,13 @@ Lista blogów prowadzonych przez polaków, lub zawierających przynajmniej czę�
 ## Dawno nieaktualizowane lub zamknięte:
 
 {% hint style="info" %}
-Blogi, które nie był aktualizowane ponad 2 lata i/lub zostało potwierdzone, że nie będą rozwijane.
+Blogi, które nie były aktualizowane ponad 2 lata i/lub zostało potwierdzone, że nie będą rozwijane.
 {% endhint %}
 
+* [https://testujemy.mobi](https://testujemy.mobi)
+  * Piotr Wicherski
 * [http://termometr.blogspot.com/](http://termometr.blogspot.com/)
   * Tomasz Zdanowicz
-* [https://web.archive.org/web/20180831224048/http://testspring.pl/blog/category/blog/](https://web.archive.org/web/20180831224048/http://testspring.pl/blog/category/blog/)
-  * Blog Stargate Technology
-* [http://web.archive.org/web/20160309122123/http://blog.alvarus.org/](http://web.archive.org/web/20160309122123/http://blog.alvarus.org/)
-  * Wersja archiwalna bloga \| Łukasz Jasiński 
 * [http://javagirl.pl/](http://javagirl.pl/)
   * JavaGirl
 * [https://martamaracje.blogspot.com/](https://martamaracje.blogspot.com/)
@@ -59,10 +51,12 @@ Blogi, które nie był aktualizowane ponad 2 lata i/lub zostało potwierdzone, �
   * Krzysztof Raczyński
 * [https://medium.com/@SimonKaz/](https://medium.com/@SimonKaz/)
   * Szymon Kazmierczak
-* [http://testerka.pl/](http://testerka.pl/)
+* [https://testerka.pl/category/blog/](https://testerka.pl/category/blog/)
   * Dorota Poręba-Połomska
 * [http://testingplus.me](http://testingplus.me)
   * Michał Ślęzak
+* [https://marcinstanek.pl/blog/](https://marcinstanek.pl/blog/)
+  * Marcin Stanek
 * [https://browserspot.com/blog/](https://browserspot.com/blog/)
   * Browser Spot
 * [https://automatingguy.com/](https://automatingguy.com/)
@@ -71,8 +65,14 @@ Blogi, które nie był aktualizowane ponad 2 lata i/lub zostało potwierdzone, �
   * Krzysztof Jadczyk
 * [http://decunadaje.pl/](http://decunadaje.pl/)
   * Daniel Dec
+* [http://blog.testuj.pl/](http://blog.testuj.pl/)
+  * Testuj.pl
 * [https://www.leanqa.pl/blog/](https://www.leanqa.pl/blog/)
   * Daniel Dec, Kamila Gawrońska, Wojciech Gawroński, Tomasz Wierzchowski
+* [https://web.archive.org/web/20180831224048/http://testspring.pl/blog/category/blog/](https://web.archive.org/web/20180831224048/http://testspring.pl/blog/category/blog/)
+  * Wersja archiwalna bloga \| Stargate Technology
+* [http://web.archive.org/web/20160309122123/http://blog.alvarus.org/](http://web.archive.org/web/20160309122123/http://blog.alvarus.org/)
+  * Wersja archiwalna bloga \| Łukasz Jasiński 
 * [https://web.archive.org/web/20230124064617/https://gregkaqa.pl/](https://web.archive.org/web/20230124064617/https://gregkaqa.pl/)
   * Wersja archiwalna bloga \| Grzegorz Kasprzak
 * [https://web.archive.org/web/20200814101238/https://devowls.io/blog/](https://web.archive.org/web/20200814101238/https://devowls.io/blog/)

--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -22,8 +22,7 @@ Lista blogów prowadzonych przez polaków, lub zawierających przynajmniej czę�
   * Maciej Kusz
 * [https://marcinstanek.pl/blog/](https://marcinstanek.pl/blog/)
   * Marcin Stanek
-* [http://decunadaje.pl/](http://decunadaje.pl/)
-  * Daniel Dec
+
 * [https://gregkaqa.pl/](https://gregkaqa.pl/)
   * Grzegorz Kasprzak
 * [http://malgosqa.pl/](http://malgosqa.pl/)
@@ -77,4 +76,6 @@ Blogi, które nie był aktualizowane ponad 2 lata i/lub zostało potwierdzone, �
   * Michał Krzyżanowski
 * [https://bugfreeblog.com/](https://bugfreeblog.com/)
   * Krzysztof Jadczyk
+* [http://decunadaje.pl/](http://decunadaje.pl/)
+  * Daniel Dec
 

--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -22,10 +22,6 @@ Lista blogów prowadzonych przez polaków, lub zawierających przynajmniej czę�
   * Maciej Kusz
 * [https://marcinstanek.pl/blog/](https://marcinstanek.pl/blog/)
   * Marcin Stanek
-* [http://malgosqa.pl/](http://malgosqa.pl/)
-  * Małgorzata Leszczuk
-* [https://www.leanqa.pl/blog/](https://www.leanqa.pl/blog/)
-  * Daniel Dec, Kamila Gawrońska, Wojciech Gawroński, Tomasz Wierzchowski
 * [https://wyszkolewas.com.pl/blog/](https://www.wyszkolewas.com.pl/blog/)
   * Waldemar Szafraniec
 * [https://jaktestowac.pl/blog/](https://jaktestowac.pl/blog/)
@@ -75,4 +71,5 @@ Blogi, które nie był aktualizowane ponad 2 lata i/lub zostało potwierdzone, �
   * Krzysztof Jadczyk
 * [http://decunadaje.pl/](http://decunadaje.pl/)
   * Daniel Dec
-
+* [https://www.leanqa.pl/blog/](https://www.leanqa.pl/blog/)
+  * Daniel Dec, Kamila Gawrońska, Wojciech Gawroński, Tomasz Wierzchowski

--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -83,4 +83,6 @@ Blogi, które nie był aktualizowane ponad 2 lata i/lub zostało potwierdzone, �
   * Łukasz Rosłonek
 * [https://projectquality.it/blog/](https://projectquality.it/blog/)
   * Krzysztof Raczyński
+* [https://medium.com/@SimonKaz/](https://medium.com/@SimonKaz/)
+  * Szymon Kazmierczak
 

--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -75,3 +75,7 @@ Blogi, które nie był aktualizowane ponad 2 lata i/lub zostało potwierdzone, �
   * Daniel Dec, Kamila Gawrońska, Wojciech Gawroński, Tomasz Wierzchowski
 * [https://web.archive.org/web/20230124064617/https://gregkaqa.pl/](https://web.archive.org/web/20230124064617/https://gregkaqa.pl/)
   * Wersja archiwalna bloga \| Grzegorz Kasprzak
+* [https://web.archive.org/web/20200814101238/https://devowls.io/blog/](https://web.archive.org/web/20200814101238/https://devowls.io/blog/)
+  * Wersja archiwalna bloga \| Michał Krzyżanowski, Michał Ślęzak
+* [https://web.archive.org/web/20201128051039/https://jakosctobedzie.pl/](https://web.archive.org/web/20201128051039/https://jakosctobedzie.pl/)
+  *  Wersja archiwalna bloga \Magda Drechsler-Nowak

--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -14,16 +14,8 @@ Lista blogów prowadzonych przez polaków, lub zawierających przynajmniej czę�
   * Sławomir Radzymiński
 * [http://jakzostactesterem.pl/](http://jakzostactesterem.pl/)
   * Blog pewnego Michała
-* [http://testingplus.me](http://testingplus.me)
-  * Michał Ślęzak
-* [https://browserspot.com/blog/](https://browserspot.com/blog/)
-  * Browser Spot
-* [https://automatingguy.com/](https://automatingguy.com/)
-  * Michał Krzyżanowski
 * [https://wyrodek.pl](https://wyrodek.pl/)
   * Maciej Wyrodek
-* [https://bugfreeblog.com/](https://bugfreeblog.com/)
-  * Krzysztof Jadczyk
 * [https://testelka.pl/blog/](https://testelka.pl/blog/)
   * Ela Sądel
 * [https://jakosctobedzie.pl/](https://jakosctobedzie.pl/)
@@ -81,4 +73,12 @@ Blogi, które nie był aktualizowane ponad 2 lata i/lub zostało potwierdzone, �
   * Szymon Kazmierczak
 * [http://testerka.pl/](http://testerka.pl/)
   * Dorota Poręba-Połomska
+* [http://testingplus.me](http://testingplus.me)
+  * Michał Ślęzak
+* [https://browserspot.com/blog/](https://browserspot.com/blog/)
+  * Browser Spot
+* [https://automatingguy.com/](https://automatingguy.com/)
+  * Michał Krzyżanowski
+* [https://bugfreeblog.com/](https://bugfreeblog.com/)
+  * Krzysztof Jadczyk
 

--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -10,10 +10,6 @@ Lista blogów prowadzonych przez polaków, lub zawierających przynajmniej czę�
   * Testerzy.pl
 * [http://blog.testuj.pl/](http://blog.testuj.pl/)
   * Testuj.pl Blog
-* [https://medium.com/@SimonKaz/](https://medium.com/@SimonKaz/)
-  * Szymon Kazmierczak
-* [http://testerka.pl/](http://testerka.pl/)
-  * Dorota Poręba-Połomska
 * [http://awesome-testing.com/](http://awesome-testing.com/)
   * Sławomir Radzymiński
 * [http://jakzostactesterem.pl/](http://jakzostactesterem.pl/)
@@ -85,4 +81,6 @@ Blogi, które nie był aktualizowane ponad 2 lata i/lub zostało potwierdzone, �
   * Krzysztof Raczyński
 * [https://medium.com/@SimonKaz/](https://medium.com/@SimonKaz/)
   * Szymon Kazmierczak
+* [http://testerka.pl/](http://testerka.pl/)
+  * Dorota Poręba-Połomska
 

--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -8,8 +8,6 @@ Lista blogów prowadzonych przez polaków, lub zawierających przynajmniej czę�
   * Piotr Wicherski
 * [http://testerzy.pl/](http://testerzy.pl/)
   * Testerzy.pl
-* [https://projectquality.it/blog/](https://projectquality.it/blog/)
-  * Krzysztof Raczyński
 * [http://blog.testuj.pl/](http://blog.testuj.pl/)
   * Testuj.pl Blog
 * [https://medium.com/@SimonKaz/](https://medium.com/@SimonKaz/)
@@ -83,4 +81,6 @@ Blogi, które nie był aktualizowane ponad 2 lata i/lub zostało potwierdzone, �
   * Marta Zajac
 * [https://test-detective.blogspot.com/](https://test-detective.blogspot.com/)
   * Łukasz Rosłonek
+* [https://projectquality.it/blog/](https://projectquality.it/blog/)
+  * Krzysztof Raczyński
 

--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -73,3 +73,5 @@ Blogi, które nie był aktualizowane ponad 2 lata i/lub zostało potwierdzone, �
   * Daniel Dec
 * [https://www.leanqa.pl/blog/](https://www.leanqa.pl/blog/)
   * Daniel Dec, Kamila Gawrońska, Wojciech Gawroński, Tomasz Wierzchowski
+* [https://web.archive.org/web/20230124064617/https://gregkaqa.pl/](https://web.archive.org/web/20230124064617/https://gregkaqa.pl/)
+  * Wersja archiwalna bloga \| Grzegorz Kasprzak

--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -18,8 +18,6 @@ Lista blogów prowadzonych przez polaków, lub zawierających przynajmniej czę�
   * Maciej Wyrodek
 * [https://testelka.pl/blog/](https://testelka.pl/blog/)
   * Ela Sądel
-* [https://devowls.io/blog/](https://devowls.io/blog/)
-  * Michał Krzyżanowski, Michał Ślęzak
 * [https://testerembyc.pl/](https://testerembyc.pl/)
   * Maciej Kusz
 * [https://marcinstanek.pl/blog/](https://marcinstanek.pl/blog/)

--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -78,4 +78,6 @@ Blogi, które nie był aktualizowane ponad 2 lata i/lub zostało potwierdzone, �
 * [https://web.archive.org/web/20200814101238/https://devowls.io/blog/](https://web.archive.org/web/20200814101238/https://devowls.io/blog/)
   * Wersja archiwalna bloga \| Michał Krzyżanowski, Michał Ślęzak
 * [https://web.archive.org/web/20201128051039/https://jakosctobedzie.pl/](https://web.archive.org/web/20201128051039/https://jakosctobedzie.pl/)
-  *  Wersja archiwalna bloga \Magda Drechsler-Nowak
+  *  Wersja archiwalna bloga \| Magda Drechsler-Nowak
+* [https://web.archive.org/web/20211223034041/http://testerslife.pl/](https://web.archive.org/web/20211223034041/http://testerslife.pl/)
+  * Wersja archiwalna bloga \| Rafał Kubik

--- a/gdzie-szukac-wiedzy/blogi.md
+++ b/gdzie-szukac-wiedzy/blogi.md
@@ -14,8 +14,6 @@ Lista blogów prowadzonych przez polaków, lub zawierających przynajmniej czę�
   * Sławomir Radzymiński
 * [http://jakzostactesterem.pl/](http://jakzostactesterem.pl/)
   * Blog pewnego Michała
-* [http://testerslife.pl](http://testerslife.pl)
-  * Rafał Kubik
 * [http://testingplus.me](http://testingplus.me)
   * Michał Ślęzak
 * [https://browserspot.com/blog/](https://browserspot.com/blog/)


### PR DESCRIPTION
Removed blogs that are no logner exist:
- Testerlife
- Jakość To Będzie
- DevOwls
- Gregkaqa

Przesunięto do nie aktywnych (kryteria brak postu conajmniej od lipca 2022)
- LeanQA
- DecuNadaje
- Michał Ślęzak
- Browser Spot
-Micahł Krzyżanowski
- Krzysztof Jadczyk
- Testerka
- Szymon Kazimierczak
- Krzysztof Raczyński